### PR TITLE
More invalid token error codes

### DIFF
--- a/PushSharp.Apple/AppleNotification.cs
+++ b/PushSharp.Apple/AppleNotification.cs
@@ -120,13 +120,13 @@ namespace PushSharp.Apple
 				throw new NotificationFailureException (2, this);
 
 			if (!IsValidDeviceRegistrationId ())
-				throw new NotificationFailureException (8, this);
+				throw new NotificationFailureException (253, this);
 
 			byte[] deviceToken = new byte[DeviceToken.Length / 2];
 			for (int i = 0; i < deviceToken.Length; i++)
 			{
 				try { deviceToken[i] = byte.Parse(DeviceToken.Substring(i*2, 2), System.Globalization.NumberStyles.HexNumber); }
-				catch (Exception) { throw new NotificationFailureException(8, this); }
+				catch (Exception) { throw new NotificationFailureException(254, this); }
 			}
 
 			if (deviceToken.Length != DEVICE_TOKEN_BINARY_SIZE)

--- a/PushSharp.Apple/AppleNotification.cs
+++ b/PushSharp.Apple/AppleNotification.cs
@@ -81,11 +81,8 @@ namespace PushSharp.Apple
 
 		public override bool IsValidDeviceRegistrationId()
 		{
-			// Apple hasn't published the format of their token, so this check may be causing
-			// all sorts of problems. Disabled 8/3/2019
-			//var r = new System.Text.RegularExpressions.Regex(@"^[0-9A-F]+$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
-			//return r.Match(this.DeviceToken).Success;
-			return !string.IsNullOrEmpty(DeviceToken);
+			var r = new System.Text.RegularExpressions.Regex(@"^[0-9A-F]+$", System.Text.RegularExpressions.RegexOptions.IgnoreCase);
+			return r.Match(this.DeviceToken).Success;
 		}
 
 		public override string ToString()

--- a/PushSharp.Apple/Exceptions.cs
+++ b/PushSharp.Apple/Exceptions.cs
@@ -76,7 +76,7 @@ namespace PushSharp.Apple
 			}
 		}
 
-		public override string ToString()
+		public string ToString_legacy()
 		{
 			var nstr = string.Empty;
 
@@ -85,6 +85,11 @@ namespace PushSharp.Apple
 
 			return string.Format("APNS NotificationFailureException -> {0} : {1} -> {2}", ErrorStatusCode, ErrorStatusDescription, nstr);
 		}
+
+		public override string ToString()
+		{
+			return string.Format("APNS NotificationFailureException -> {0} : {1}", ErrorStatusCode, ErrorStatusDescription);
+		}
 	}
-	
+
 }

--- a/PushSharp.Apple/Exceptions.cs
+++ b/PushSharp.Apple/Exceptions.cs
@@ -57,7 +57,13 @@ namespace PushSharp.Apple
 						msg = "Invalid payload size";
 						break;
 					case 8:
-						msg = "Invalid token";
+						msg = $"Invalid token - {Notification.DeviceToken}";
+						break;
+					case 253:
+						msg = $"Invalid token(1) - {Notification.DeviceToken}";
+						break;
+					case 254:
+						msg = $"Invalid token(2) - {Notification.DeviceToken}";
 						break;
 					case 255:
 						msg = "None (unknown)";


### PR DESCRIPTION
Changed invalid token codes to make it easier to see where the invalid tokens are coming from:
1. from PushSharp caller
2. from Apple